### PR TITLE
add ability to dynamically update the reset voltage

### DIFF
--- a/scripts/fullFieldUncaging.bsh
+++ b/scripts/fullFieldUncaging.bsh
@@ -23,7 +23,9 @@ buffer = 50; // buffer time in milliseconds
 uncaging = new Runnable() {
     int count = 0;
     public void run() {
-        led_control_async(global.port, global.dac, global.power, global.uncaging_length_secs*1000);
+        // this is a non-tracking async call since it shouldn't care about the status of
+        // other async calls, this should dominate
+        led_control_async(global.port, global.dac, global.power, global.uncaging_length_secs*1000, false);
     }
 };
 
@@ -33,7 +35,8 @@ blanker = new Runnable() {
     int channel = 0;
     public void run() {
         exposure_time = (int)global.settings.channels.get(channel).exposure + global.buffer;
-        led_control_async(global.port, global.dac, 0.0, exposure_time);
+        // this should track whatever the master async call is doing
+        led_control_async(global.port, global.dac, 0.0, exposure_time, true);
 
         channel = (channel + 1) % num_channels;
     }

--- a/scripts/led_control.bsh
+++ b/scripts/led_control.bsh
@@ -44,7 +44,7 @@ led_control(String port, String dac, double voltage) {
 	mmc.writeToSerialPort(port, message);
 }
 
-led_control_async(String port, String dac, double voltage, int time) {
+led_control_async(String port, String dac, double voltage, int time, bool tracking) {
 	long start_time = System.currentTimeMillis();
 	prev_voltage = global.current_led_voltage;
 	led_control(port, dac, voltage);
@@ -53,9 +53,13 @@ led_control_async(String port, String dac, double voltage, int time) {
 		public void run() {
 			while (true) {
 				long timeleft = super.time - (System.currentTimeMillis() - super.start_time);
+				// if we're tracking voltage than we need to update our target voltage whenever it
+				// changes in the background
+				if (super.tracking && global.current_led_voltage != super.prev_voltage) {
+					super.prev_voltage = global.current_led_voltage;
+				}
 				if (timeleft < 0) {
 					led_control(super.port, super.dac, super.prev_voltage); // restore voltage
-					global.current_led_voltage = super.prev_voltage;
 					break;
 				}
 			}


### PR DESCRIPTION
The shuttering async calls should be "tracking", i.e. they shouldn't remember an old outdated target voltage since that might change in the meantime. So if the global led state changes while a tracking async call is waiting, it'll update the target voltage to whatever the new global state is.